### PR TITLE
fix offsetTop, add zIndex prop 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Demo at [https://stickydivdemo.herokuapp.com/#/][2]
 ## Usage
 
 #### Options 
- * {int} offsetTop - The offset from the top of the page, optional 
+ * {int} offsetTop - The offset from the top of the page, optional; default: 0 
+ * {int} zIndex - The zIndex for the sticky element, optional; default: 999 
  
 #### With JSX
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Demo at [https://stickydivdemo.herokuapp.com/#/][2]
 
 ## Usage
 
-
+#### Options 
+ * {int} offsetTop - The offset from the top of the page, optional 
+ 
 #### With JSX
 
     var StickyDiv = require('react-stickydiv');

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ var SimplePageScrollMixin = {
   },
   componentWillUnmount: function () {
     window.removeEventListener('scroll', this.onScroll, false);
-  }
+  },
 };
 var SimpleResizeMixin = {
   componentDidMount: function() {
@@ -64,10 +64,17 @@ var SimpleResizeMixin = {
   }
 };
 
-module.exports = React.createClass({displayName: "StickyDiv",
+var StickyDiv = React.createClass({displayName: "StickyDiv",
   mixins: [SimplePageScrollMixin, SimpleResizeMixin],
   getInitialState : function(){
     return {fix: false};
+  },
+  getDefaultProps: function() {
+    return {
+      offsetTop: 0,
+      className: '',
+      zIndex: 9999
+    };
   },
   handleResize : function(){
     this.checkPositions();
@@ -77,7 +84,7 @@ module.exports = React.createClass({displayName: "StickyDiv",
   },
   checkPositions: function(){
     var pos = util.findPosRelativeToViewport(this.getDOMNode());
-    if (pos[1]<0){
+    if (pos[1]<this.props.offsetTop){
       this.setState({fix: true});
     } else {
       this.setState({fix: false});
@@ -85,22 +92,16 @@ module.exports = React.createClass({displayName: "StickyDiv",
   },
   render: function () {
     var divStyle;
-    var className;
-    var offsetTop = 0;
-    if("undefined" !== typeof this.props.className)
-      className=this.props.className;
-    if("undefined" !== typeof this.props.offsetTop)
-      offsetTop=this.props.offsetTop;
 
     if (this.state.fix) {
       divStyle = {
         display: 'block',
         position: 'fixed',
         width: this.refs.original.getDOMNode().getBoundingClientRect().width + 'px',
-        top: offsetTop
-      }
-      return React.createElement("div", {style: {'zIndex' : 99, position:'relative', width:'100%'}},
-          React.createElement("div", {key: "duplicate", className: className, style: divStyle},
+        top: this.props.offsetTop
+      };
+      return React.createElement("div", {style: {'zIndex' : this.props.zIndex, position:'relative', width:'100%'}},
+          React.createElement("div", {key: "duplicate", className: this.props.className, style: divStyle},
               this.props.children
           ),
           React.createElement("div", {ref: "original", key: "original", style: {visibility:'hidden'}},
@@ -113,7 +114,7 @@ module.exports = React.createClass({displayName: "StickyDiv",
         display: 'block',
         position: 'relative'
       };
-      return React.createElement("div", {style: {'zIndex' : 99, position:'relative', width:'100%'}},
+      return React.createElement("div", {style: {'zIndex' : this.props.zIndex, position:'relative', width:'100%'}},
           React.createElement("div", {ref: "original", key: "original", style: divStyle},
               this.props.children
           )
@@ -121,3 +122,5 @@ module.exports = React.createClass({displayName: "StickyDiv",
     }
   }
 });
+
+module.exports = StickyDiv;

--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ module.exports = React.createClass({displayName: "StickyDiv",
   },
   render: function () {
     var divStyle;
+    var className;
+    if("undefined" !== typeof this.props.className)
+      className=this.props.className;
 
     if (this.state.fix) {
       divStyle = {
@@ -94,7 +97,7 @@ module.exports = React.createClass({displayName: "StickyDiv",
         top: 0
       };
       return React.createElement("div", {style: {'zIndex' : 99, position:'relative', width:'100%'}},
-          React.createElement("div", {key: "duplicate", style: divStyle},
+          React.createElement("div", {key: "duplicate", className: className, style: divStyle},
               this.props.children
           ),
           React.createElement("div", {ref: "original", key: "original", style: {visibility:'hidden'}},

--- a/index.js
+++ b/index.js
@@ -86,16 +86,19 @@ module.exports = React.createClass({displayName: "StickyDiv",
   render: function () {
     var divStyle;
     var className;
+    var offsetTop = 0;
     if("undefined" !== typeof this.props.className)
       className=this.props.className;
+    if("undefined" !== typeof this.props.offsetTop)
+      offsetTop=this.props.offsetTop;
 
     if (this.state.fix) {
       divStyle = {
         display: 'block',
         position: 'fixed',
         width: this.refs.original.getDOMNode().getBoundingClientRect().width + 'px',
-        top: 0
-      };
+        top: offsetTop
+      }
       return React.createElement("div", {style: {'zIndex' : 99, position:'relative', width:'100%'}},
           React.createElement("div", {key: "duplicate", className: className, style: divStyle},
               this.props.children

--- a/index.jsx
+++ b/index.jsx
@@ -1,0 +1,116 @@
+/** @jsx React.DOM */
+"use strict";
+
+var util = {
+
+    // findPos() by quirksmode.org
+    // Finds the absolute position of an element on a page
+    findPos: function (obj) {
+        var curleft = 0,
+            curtop = 0;
+        if (obj.offsetParent) {
+            do {
+                curleft += obj.offsetLeft;
+                curtop += obj.offsetTop;
+            } while (obj = obj.offsetParent);
+        }
+        return [curleft, curtop];
+    },
+
+    // getPageScroll() by quirksmode.org
+    // Finds the scroll position of a page
+    getPageScroll: function () {
+        var xScroll, yScroll;
+        if (self.pageYOffset) {
+            yScroll = self.pageYOffset;
+            xScroll = self.pageXOffset;
+        } else if (document.documentElement && document.documentElement.scrollTop) {
+            yScroll = document.documentElement.scrollTop;
+            xScroll = document.documentElement.scrollLeft;
+        } else if (document.body) {// all other Explorers
+            yScroll = document.body.scrollTop;
+            xScroll = document.body.scrollLeft;
+        }
+        return [xScroll, yScroll]
+    },
+
+    // Finds the position of an element relative to the viewport.
+    findPosRelativeToViewport: function (obj) {
+        var objPos = this.findPos(obj)
+        var scroll = this.getPageScroll()
+        return [ objPos[0] - scroll[0], objPos[1] - scroll[1] ]
+    }
+
+}
+
+var SimplePageScrollMixin = {
+    componentDidMount: function () {
+        window.addEventListener('scroll', this.onScroll, false);
+    },
+    componentWillUnmount: function () {
+        window.removeEventListener('scroll', this.onScroll, false);
+    },
+};
+var SimpleResizeMixin = {
+    componentDidMount: function() {
+        window.addEventListener('resize', this.handleResize);
+    },
+
+    componentWillUnmount: function() {
+        window.removeEventListener('resize', this.handleResize);
+    }
+};
+
+var StickyDiv = React.createClass({
+    mixins: [SimplePageScrollMixin, SimpleResizeMixin],
+    getInitialState : function(){
+        return {fix: false};
+    },
+    handleResize : function(){
+        this.checkPositions();
+    },
+    onScroll: function () {
+        this.checkPositions();
+    },
+    checkPositions: function(){
+        var pos = util.findPosRelativeToViewport(this.getDOMNode());
+        if (pos[1]<0){
+            this.setState({fix: true});
+        } else {
+            this.setState({fix: false});
+        }
+    },
+    render: function () {
+        var divStyle, className;
+        if("undefined" !== typeof this.props.className)
+            className=this.props.className;
+
+        if (this.state.fix) {
+            divStyle = {
+                display: 'block',
+                position: 'fixed',
+                width: this.refs.original.getDOMNode().getBoundingClientRect().width + 'px',
+                top: 0
+            }
+            return <div style={{'zIndex' : 99999, position:'relative', width:'100%'}}>
+                <div key='duplicate' className={className} style={divStyle}>
+            {this.props.children}
+                </div>
+                <div ref='original' key='original' style={{visibility:'hidden'}}>
+            {this.props.children}
+                </div>
+            </div>;
+        }
+        else {
+            divStyle = {
+                display: 'block',
+                position: 'relative'
+            }
+            return <div style={{'zIndex' : 99999, position:'relative', width:'100%'}}>
+                <div ref='original' key='original' style={divStyle}>
+          {this.props.children}
+                </div>
+            </div>;
+        }
+    }
+});

--- a/index.jsx
+++ b/index.jsx
@@ -81,16 +81,18 @@ var StickyDiv = React.createClass({
         }
     },
     render: function () {
-        var divStyle, className;
+        var divStyle, className, offsetTop = 0;
         if("undefined" !== typeof this.props.className)
             className=this.props.className;
+        if("undefined" !== typeof this.props.offsetTop)
+            offsetTop=this.props.offsetTop;
 
         if (this.state.fix) {
             divStyle = {
                 display: 'block',
                 position: 'fixed',
                 width: this.refs.original.getDOMNode().getBoundingClientRect().width + 'px',
-                top: 0
+                top: offsetTop
             }
             return <div style={{'zIndex' : 99999, position:'relative', width:'100%'}}>
                 <div key='duplicate' className={className} style={divStyle}>

--- a/index.jsx
+++ b/index.jsx
@@ -1,6 +1,9 @@
 /** @jsx React.DOM */
 "use strict";
 
+if("undefined" == typeof React)
+    var React = require('react');
+
 var util = {
 
     // findPos() by quirksmode.org
@@ -66,6 +69,13 @@ var StickyDiv = React.createClass({
     getInitialState : function(){
         return {fix: false};
     },
+    getDefaultProps: function() {
+        return {
+            offsetTop: 0,
+            className: '',
+            zIndex: 9999
+        };
+    },
     handleResize : function(){
         this.checkPositions();
     },
@@ -74,28 +84,24 @@ var StickyDiv = React.createClass({
     },
     checkPositions: function(){
         var pos = util.findPosRelativeToViewport(this.getDOMNode());
-        if (pos[1]<0){
+        if (pos[1]<this.props.offsetTop){
             this.setState({fix: true});
         } else {
             this.setState({fix: false});
         }
     },
     render: function () {
-        var divStyle, className, offsetTop = 0;
-        if("undefined" !== typeof this.props.className)
-            className=this.props.className;
-        if("undefined" !== typeof this.props.offsetTop)
-            offsetTop=this.props.offsetTop;
+        var divStyle;
 
         if (this.state.fix) {
             divStyle = {
                 display: 'block',
                 position: 'fixed',
                 width: this.refs.original.getDOMNode().getBoundingClientRect().width + 'px',
-                top: offsetTop
-            }
-            return <div style={{'zIndex' : 99999, position:'relative', width:'100%'}}>
-                <div key='duplicate' className={className} style={divStyle}>
+                top: this.props.offsetTop
+            };
+            return <div style={{'zIndex' : this.props.zIndex, position:'relative', width:'100%'}}>
+                <div key='duplicate' className={this.props.className} style={divStyle}>
             {this.props.children}
                 </div>
                 <div ref='original' key='original' style={{visibility:'hidden'}}>
@@ -107,8 +113,8 @@ var StickyDiv = React.createClass({
             divStyle = {
                 display: 'block',
                 position: 'relative'
-            }
-            return <div style={{'zIndex' : 99999, position:'relative', width:'100%'}}>
+            };
+            return <div style={{'zIndex' : this.props.zIndex, position:'relative', width:'100%'}}>
                 <div ref='original' key='original' style={divStyle}>
           {this.props.children}
                 </div>
@@ -116,3 +122,5 @@ var StickyDiv = React.createClass({
         }
     }
 });
+
+module.exports = StickyDiv;


### PR DESCRIPTION
Sorry but I fixed a little bug. The offsetTop prop is now checked in the checkPos function 

and maybe we remove the zIndex prop and add a simple class name if state is fix, like:  

```javascript
 if (this.state.fix) {
     this.props.className = this.props.className + ' sticky'
...
```
So you can set some custom zIndex and other styles in your stylesheet.  
I need a custom zIndex because a active Menue should overlap the sticky div. 
 