### PR TITLE
keep original children visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,12 +110,12 @@ var StickyDiv = React.createClass({
                 { style: { zIndex: this.props.zIndex, position: "relative", width: "100%" } },
                 React.createElement(
                     "div",
-                    { key: "duplicate", className: this.props.className, style: divStyle },
+                    { key: "duplicate", style: { visibility: "hidden" } },
                     this.props.children
                 ),
                 React.createElement(
                     "div",
-                    { ref: "original", key: "original", style: { visibility: "hidden" } },
+                    { ref: "original", key: "original", className: this.props.className, style: divStyle },
                     this.props.children
                 )
             );

--- a/index.jsx
+++ b/index.jsx
@@ -105,12 +105,15 @@ var StickyDiv = React.createClass({
                 top: this.props.offsetTop
             };
             return <div style={{zIndex : this.props.zIndex, position:'relative', width:'100%'}}>
-                <div key='duplicate' className={this.props.className} style={divStyle}>
+
+                <div key='duplicate' style={{visibility:'hidden'}}>
             {this.props.children}
                 </div>
-                <div ref='original' key='original' style={{visibility:'hidden'}}>
+
+                <div ref='original' key='original' className={this.props.className} style={divStyle} >
             {this.props.children}
                 </div>
+
             </div>;
         }
         else {

--- a/index.jsx
+++ b/index.jsx
@@ -105,15 +105,12 @@ var StickyDiv = React.createClass({
                 top: this.props.offsetTop
             };
             return <div style={{zIndex : this.props.zIndex, position:'relative', width:'100%'}}>
-
                 <div key='duplicate' style={{visibility:'hidden'}}>
             {this.props.children}
                 </div>
-
                 <div ref='original' key='original' className={this.props.className} style={divStyle} >
             {this.props.children}
                 </div>
-
             </div>;
         }
         else {


### PR DESCRIPTION
Hey @svenanders, react-stickydiv was a great drop-in sticky header. Only bump I ran into was:

I have some state in the header, and the way you are swapping original and duplicate, when the header gets swapped, it loses the state (since the original gets hidden and replaced with a different set of children). This PR keeps the original always visible and instead hides the duplicate. That way state is retained, and the duplicate is used simply to keep the original content size.

Side note: your Makefile is expecting a global node_module (uglify-js) to be installed in a particular place, but my system has global modules in the home directory (~). Could you just make uglify-js a dependency and run from `./node_modules/uglify-js`?

Thanks!