### PR TITLE
Prevent conflict for older versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dom-find": "^0.3.1"
   },
   "peerDependencies": {
-    "react": ">=0.14",
-    "react-dom": ">=0.14"
+    "react": "0.14.x",
+    "react-dom": "0.14.x"
   },
   "devDependencies": {
     "babel": "^5.1.13",


### PR DESCRIPTION
Because of React 0.14 release older versions that are require `>=0.12` can make a conflict with other peer dependencies

That's what I have now:

```
08:08:42 npm ERR! peerinvalid Peer react-motion@0.2.7 wants react@>=0.13.2 || ^0.14.0-beta1
08:08:42 npm ERR! peerinvalid Peer react-router@1.0.0-beta1 wants react@0.13.x
08:08:42 npm ERR! peerinvalid Peer react-stickydiv@3.4.15 wants react@>=0.14
```